### PR TITLE
Separate QC reports and separate output folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pipeline visualized below
     -   ggplot2 3.4.4
     -   data.table 1.14.8
     -   dplyr 1.1.3
-    -   Seurat 4.9.9
+    -   Seurat \>5.0
     -   progressr 0.14.0
     -   kableExtra 1.3.4
     -   ComplexHeatmap 2.15.4
@@ -43,20 +43,20 @@ Note: This pipeline requires exported QuPath (0.4.3) measurement tables (quantif
 
 ### Configurable parameters
 
-| object               | value                                                                                                     |
-|----------------------|-----------------------------------------------------------------------------------------------------------|
-| sigsum_quantile_high | Upper quantile cutoff for sigsum filtering (default 0.99)                                                 |
-| sigsum_quantile_low  | Lower quantile cutoff for sigsum filtering (default 0.05)                                                 |
-| bin_size             | Size of bounding box for low-density cell search (default 50)                                             |
-| density_cutoff       | Cutoff number of cells defined as low-density (default 5)                                                 |
-| cluster_metric       | Metric to use for Seurat clustering (default Median)                                                      |
-| clustering_res       | If specified, this clustering resolution will be used for all ROIs and will override the clustree method. |
-| min_res              | Minimum clustering resolution to search with clustree (default 0.1)                                       |
-| max_res              | Maximum clustering resolution to search with clustree (default 1.9)                                       |
-| res_step             | Increment for searching clustering resolutions; functions as `by` argument in `seq()` (default 0.2)       |
-| min_clusters         | Minimum number of clusters for per-ROI clustering in Seurat (default 6)                                   |
-| min_metaclusters     | Starting number of metaclusters to create (default 5)                                                     |
-| max_metaclusters     | Ending number of metaclusters to create (default 10)                                                      |
+| object               | value                                                                                                                                                     |
+|-----------------|-------------------------------------------------------|
+| sigsum_quantile_high | Upper quantile cutoff for sigsum filtering (default 0.99)                                                                                                 |
+| sigsum_quantile_low  | Lower quantile cutoff for sigsum filtering (default 0.05)                                                                                                 |
+| bin_size             | Size of bounding box for low-density cell search (default 50)                                                                                             |
+| density_cutoff       | Cutoff number of cells defined as low-density (default 5)                                                                                                 |
+| cluster_metric       | Metric to use for Seurat clustering (default Median)                                                                                                      |
+| clustering_res       | If specified, this clustering resolution will be used for all ROIs and will override the clustree method. Set to NA or remove row to use clustree method. |
+| min_res              | Minimum clustering resolution to search with clustree (default 0.1)                                                                                       |
+| max_res              | Maximum clustering resolution to search with clustree (default 1.9)                                                                                       |
+| res_step             | Increment for searching clustering resolutions; functions as `by` argument in `seq()` (default 0.2)                                                       |
+| min_clusters         | Minimum number of clusters for per-ROI clustering in Seurat (default 6)                                                                                   |
+| min_metaclusters     | Starting number of metaclusters to create (default 5)                                                                                                     |
+| max_metaclusters     | Ending number of metaclusters to create (default 10)                                                                                                      |
 
 ------------------------------------------------------------------------
 
@@ -64,25 +64,24 @@ Note: This pipeline requires exported QuPath (0.4.3) measurement tables (quantif
 
 **QC.Rmd**
 
--   QC_report\_\<roi_name\>.html
-    -   One report per ROI
-    -   Includes plots for sigsum cutoffs and bin density flags
-    -   Reports how many cells were flagged by each metric
--   all_markers_clean\_\<roi_name\>.csv
+-   `output_reports/bin_density_report.html` and `output_reports/sigsum_report.html`
+    -   Reports contain one QC image for each ROI
+    -   Plots for sigsum cutoffs and bin density flags
+-   `output_tables/all_markers_clean_<roi_name>.csv`
     -   Quantification file in the same format as input files but with additional columns for QC metrics and QC flags
 
 **clustering.Rmd**
 
--   clustering_report\_\<roi_name\>.html
+-   `output_reports/clustering_report_<roi_name>.html`
     -   Clustree plot, selected resolution, marker vs cluster heatmaps and ridgeplots
--   clusters\_\<roi_name\>.html
+-   `output_tables/clusters_<roi_name>.html`
     -   Clusters mapped to cell coordinates - includes artifacts
 
 **metaclustering.Rmd**
 
--   metaclustering_report.html
+-   `output_reports/metaclustering_report.html`
     -   Marker vs metacluster heatmaps; barplots for proportion of ROI per metacluster
--   \<roi_name\>\_mapped_metaclusters_n\_metaclusters.csv
+-   `output_tables/<roi_name>_mapped_metaclusters_n_metaclusters.csv`
     -   Clusters and metaclusters mapped to cell coordinates - includes artifacts
 
 ------------------------------------------------------------------------

--- a/scripts/QC.Rmd
+++ b/scripts/QC.Rmd
@@ -107,7 +107,9 @@ ggplot(data = means_only_df, aes(x = sigsum)) +
   geom_histogram() +
   theme_bw() +
   geom_vline(aes(xintercept = sigsum_cutpoint_1)) +
-  geom_vline(aes(xintercept = sigsum_cutpoint_2))
+  geom_vline(aes(xintercept = sigsum_cutpoint_2)) +
+  ggtitle(roi)
+ggsave(paste0("sigsum_", roi, ".png"), device = "png", dpi = 300, width = 6, height = 5, units = "in")
 ```
 
 
@@ -135,7 +137,9 @@ ggplot(roi_df, aes(x = roi_df$`Centroid X`, y = roi_df$`Centroid Y`, fill = roi_
   geom_point(pch=21,colour="white") +
   labs(x = "Centroid X", y = "Centroid Y", fill = "Low bin density") +
   scale_y_reverse() +
-  theme_minimal()
+  theme_minimal() +
+  ggtitle(roi)
+ggsave(paste0("bin_density_", roi, ".png"), device = "png", dpi = 300, width = 6, height = 5, units = "in")
 ```
 
 

--- a/scripts/collect_bin_density.Rmd
+++ b/scripts/collect_bin_density.Rmd
@@ -1,0 +1,46 @@
+---
+title: "Bin Density QC Plots"
+date: "`r format(Sys.time(), '%d %B, %Y')`"
+params:
+  bin_density_collected: ""
+output:
+  html_document:
+    code_folding: hide
+    df_print: paged 
+    geometry: margin=2cm
+    highlight: textmate
+    theme: journal
+    fig_crop: false
+  pdf_document: default
+---
+<style type="text/css">
+.main-container {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+}
+</style>
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE)
+```
+
+```{r results='asis'}
+all_bin_density <- sort(unlist(strsplit(params$bin_density_collected, ",")))
+
+# Loop through the list and display images
+for (img_path in all_bin_density) {
+  cat(paste0('<img src="', img_path, '" width="500"/><br>'))
+}
+```
+
+
+
+
+
+
+
+
+
+
+

--- a/scripts/collect_sigsum.Rmd
+++ b/scripts/collect_sigsum.Rmd
@@ -1,0 +1,46 @@
+---
+title: "Bin Density QC Plots"
+date: "`r format(Sys.time(), '%d %B, %Y')`"
+params:
+  sigsum_collected: ""
+output:
+  html_document:
+    code_folding: hide
+    df_print: paged 
+    geometry: margin=2cm
+    highlight: textmate
+    theme: journal
+    fig_crop: false
+  pdf_document: default
+---
+<style type="text/css">
+.main-container {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+}
+</style>
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE)
+```
+
+```{r results='asis'}
+all_sigsum <- sort(unlist(strsplit(params$sigsum_collected, ",")))
+
+# Loop through the list and display images
+for (img_path in all_sigsum) {
+  cat(paste0('<img src="', img_path, '" width="500"/><br>'))
+}
+```
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
QC plots now have two reports for all ROIs (sigsum_report.html and bin_density_report.html). Easier for projects with lots of ROIs. Reports and tables are split into their own directories (output_reports and output_tables). This makes it easier to find reports when there may be many output tables.